### PR TITLE
Fixing Makefile typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ pkg_dummy_weather:dummy_weather pkg_resources
 pkg_resources:
 	@echo "Packaging resources..."
 	@mkdir -p $(BUILD_RESOURCES_DIR)
-	@cp -r resources/ $(BUILD_RESOURCES_DIR)
+	@cp -r resources/* $(BUILD_RESOURCES_DIR)
 
 dummy_weather: dummy_weather.go test
 	@echo "Building exec..."


### PR DESCRIPTION
The way the Makefile is written right now, the cities ends up
in `$GOPATH/bin/resources/resources/cities.json` instead of
`$GOPATH/bin/resources/cities.json`.

This fixes that ;-).
